### PR TITLE
Closes #51 Improve code comments in example scripts

### DIFF
--- a/__temp6/Average.fs
+++ b/__temp6/Average.fs
@@ -1,0 +1,11 @@
+﻿namespace Algorithms.Math
+
+module Average =
+    let inline average (xs: ^a list) =
+        match xs with
+        | [] -> None
+        | _ ->
+            let sum, count = List.fold (fun (sum, count) current -> (sum + current, count + 1))
+                                       (LanguagePrimitives.GenericZero, 0)
+                                       xs
+            LanguagePrimitives.DivideByInt sum count |> Some                              

--- a/__temp6/Fibonacci.scala
+++ b/__temp6/Fibonacci.scala
@@ -1,0 +1,14 @@
+package Mathematics
+
+object Fibonacci {
+  private val allFibonacci: LazyList[Int] = 1 #:: 1 #:: allFibonacci.zip(allFibonacci.tail).map(t => t._1 + t._2)
+
+  /** Method to use the allFibonacci stream to take the first total numbers Using streams is both an easy and
+    * efficient way to generate fibonacci numbers (streams are memoized)
+    *
+    * @param total
+    *   Maximum number of elements of the sequence
+    * @return
+    */
+  def fibGenerate(total: Int): Seq[Int] = allFibonacci.take(total)
+}

--- a/__temp6/chaining.cpp
+++ b/__temp6/chaining.cpp
@@ -1,0 +1,186 @@
+/**
+ * @file chaining.cpp
+ * @author [vasutomar](https://github.com/vasutomar)
+ * @author [Krishna Vedala](https://github.com/kvedala)
+ * @brief Implementation of [hash
+ * chains](https://en.wikipedia.org/wiki/Hash_chain).
+ */
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+/**
+ * @brief Chain class with a given modulus
+ */
+class hash_chain {
+ private:
+    /**
+     * @brief Define a linked node
+     */
+    using Node = struct Node {
+        int data{};                         ///< data stored in the node
+        std::shared_ptr<struct Node> next;  ///< pointer to the next node
+    };
+
+    std::vector<std::shared_ptr<Node>> head;  ///< array of nodes
+    int _mod;                                 ///< modulus of the class
+
+ public:
+    /**
+     * @brief Construct a new chain object
+     *
+     * @param mod modulus of the chain
+     */
+    explicit hash_chain(int mod) : _mod(mod) {
+        while (mod--) head.push_back(nullptr);
+    }
+
+    /**
+     * @brief create and add a new node with a give value and at a given height
+     *
+     * @param x value at the new node
+     * @param h height of the node
+     */
+    void add(int x, int h) {
+        std::shared_ptr<Node> curr;
+        std::shared_ptr<Node> temp(new Node);
+        temp->data = x;
+        temp->next = nullptr;
+        if (!head[h]) {
+            head[h] = temp;
+            curr = head[h];
+        } else {
+            curr = head[h];
+            while (curr->next) curr = curr->next;
+            curr->next = temp;
+        }
+    }
+
+    /**
+     * @brief Display the chain
+     */
+    void display() {
+        std::shared_ptr<Node> temp = nullptr;
+        int i = 0;
+        for (i = 0; i < _mod; i++) {
+            if (!head[i]) {
+                std::cout << "Key " << i << " is empty" << std::endl;
+            } else {
+                std::cout << "Key " << i << " has values = " << std::endl;
+                temp = head[i];
+                while (temp->next) {
+                    std::cout << temp->data << " " << std::endl;
+                    temp = temp->next;
+                }
+                std::cout << temp->data;
+                std::cout << std::endl;
+            }
+        }
+    }
+
+    /**
+     * @brief Compute the hash of a value for current chain
+     *
+     * @param x value to compute modulus of
+     * @return modulus of `x`
+     * @note declared as a
+     * [`virtual`](https://en.cppreference.com/w/cpp/language/virtual) so that
+     * custom implementations of the class can modify the hash function.
+     */
+    virtual int hash(int x) const { return x % _mod; }
+
+    /**
+     * @brief Find if a value and corresponding hash exist
+     *
+     * @param x value to search for
+     * @param h corresponding hash key
+     * @returns `true` if element found
+     * @returns `false` if element not found
+     */
+    bool find(int x, int h) const {
+        std::shared_ptr<Node> temp = head[h];
+        if (!head[h]) {
+            // index does not exist!
+            std::cout << "Element not found" << std::endl;
+            return false;
+        }
+
+        // scan for data value
+        while (temp->data != x && temp->next) temp = temp->next;
+
+        if (temp->next) {
+            std::cout << "Element found" << std::endl;
+            return true;
+        }
+
+        // implicit else condition
+        // i.e., temp->next == nullptr
+        if (temp->data == x) {
+            std::cout << "Element found" << std::endl;
+            return true;
+        }
+
+        // further implicit else condition
+        std::cout << "Element not found" << std::endl;
+        return false;
+    }
+};
+
+/** Main function
+ * @returns `0` always
+ */
+int main() {
+    int c = 0, x = 0, mod = 0, h = 0;
+    std::cout << "Enter the size of Hash Table. = " << std::endl;
+    std::cin >> mod;
+
+    hash_chain mychain(mod);
+
+    bool loop = true;
+    while (loop) {
+        std::cout << std::endl;
+        std::cout << "PLEASE CHOOSE -" << std::endl;
+        std::cout << "1. Add element." << std::endl;
+        std::cout << "2. Find element." << std::endl;
+        std::cout << "3. Generate Hash." << std::endl;
+        std::cout << "4. Display Hash table." << std::endl;
+        std::cout << "5. Exit." << std::endl;
+        std::cin >> c;
+        switch (c) {
+            case 1:
+                std::cout << "Enter element to add = " << std::endl;
+                std::cin >> x;
+                h = mychain.hash(x);
+                h = std::abs(h);
+                mychain.add(x, h);
+                break;
+            case 2:
+                std::cout << "Enter element to search = " << std::endl;
+                std::cin >> x;
+                h = mychain.hash(x);
+                mychain.find(x, h);
+                break;
+            case 3:
+                std::cout << "Enter element to generate hash = " << std::endl;
+                std::cin >> x;
+                std::cout << "Hash of " << x << " is = " << mychain.hash(x)
+                          << std::endl;
+                break;
+            case 4:
+                mychain.display();
+                break;
+            default:
+                loop = false;
+                break;
+        }
+        std::cout << std::endl;
+    }
+    /*add(1,&head1);
+    add(2,&head1);
+    add(3,&head2);
+    add(5,&head1);
+    display(&head1);
+    display(&head2);*/
+    return 0;
+}

--- a/__temp6/eulertotient_test.go
+++ b/__temp6/eulertotient_test.go
@@ -1,0 +1,44 @@
+package math
+
+import (
+	"testing"
+)
+
+func getTestsForPhi() []struct {
+	n        int64
+	expected int64
+} {
+	var tests = []struct {
+		n        int64
+		expected int64
+	}{
+		{4, 2},
+		{5, 4},
+		{7, 6},
+		{10, 4},
+		{999, 648},
+		{1000, 400},
+		{1000000, 400000},
+		{999999, 466560},
+		{999999999999878, 473684210526240},
+	}
+	return tests
+}
+
+func TestPhi(t *testing.T) {
+
+	tests := getTestsForPhi()
+	for _, test := range tests {
+		result := Phi(test.n)
+		t.Log(test.n, " ", result)
+		if result != test.expected {
+			t.Errorf("Wrong result! Expected:%v, returned:%v ", test.expected, result)
+		}
+	}
+}
+
+func BenchmarkPhi(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Phi(65536)
+	}
+}

--- a/__temp6/lowestcommonancestor.go
+++ b/__temp6/lowestcommonancestor.go
@@ -1,0 +1,123 @@
+// lowestcommonancestor.go
+// description: Implementation of Lowest common ancestor (LCA) algorithm.
+// detail:
+// Let `T` be a tree. The LCA of `u` and `v` in T is the shared ancestor of `u` and `v`
+// that is located farthest from the root.
+// time complexity: O(n log n) where n is the number of vertices in the tree
+// space complexity: O(n log n) where n is the number of vertices in the tree
+// references: [cp-algorithms](https://cp-algorithms.com/graph/lca_binary_lifting.html)
+// author(s) [Dat](https://github.com/datbeohbbh)
+// see lowestcommonancestor_test.go for a test implementation.
+
+package graph
+
+type TreeEdge struct {
+	from int
+	to   int
+}
+
+type ITree interface {
+	dfs(int, int)
+	addEdge(int, int)
+	GetDepth(int) int
+	GetDad(int) int
+	GetLCA(int, int) int
+}
+
+type Tree struct {
+	numbersVertex int
+	root          int
+	MAXLOG        int
+	depth         []int
+	dad           []int
+	jump          [][]int
+	edges         [][]int
+}
+
+func (tree *Tree) addEdge(u, v int) {
+	tree.edges[u] = append(tree.edges[u], v)
+	tree.edges[v] = append(tree.edges[v], u)
+}
+
+func (tree *Tree) dfs(u, par int) {
+	tree.jump[0][u] = par
+	tree.dad[u] = par
+	for _, v := range tree.edges[u] {
+		if v != par {
+			tree.depth[v] = tree.depth[u] + 1
+			tree.dfs(v, u)
+		}
+	}
+}
+
+func (tree *Tree) GetDepth(u int) int {
+	return tree.depth[u]
+}
+
+func (tree *Tree) GetDad(u int) int {
+	return tree.dad[u]
+}
+
+func (tree *Tree) GetLCA(u, v int) int {
+	if tree.GetDepth(u) < tree.GetDepth(v) {
+		u, v = v, u
+	}
+
+	for j := tree.MAXLOG - 1; j >= 0; j-- {
+		if tree.GetDepth(tree.jump[j][u]) >= tree.GetDepth(v) {
+			u = tree.jump[j][u]
+		}
+	}
+
+	if u == v {
+		return u
+	}
+
+	for j := tree.MAXLOG - 1; j >= 0; j-- {
+		if tree.jump[j][u] != tree.jump[j][v] {
+			u = tree.jump[j][u]
+			v = tree.jump[j][v]
+		}
+	}
+
+	return tree.jump[0][u]
+}
+
+func NewTree(numbersVertex, root int, edges []TreeEdge) (tree *Tree) {
+	tree = new(Tree)
+	tree.numbersVertex, tree.root, tree.MAXLOG = numbersVertex, root, 0
+	tree.depth = make([]int, numbersVertex)
+	tree.dad = make([]int, numbersVertex)
+
+	for (1 << tree.MAXLOG) <= numbersVertex {
+		(tree.MAXLOG) += 1
+	}
+	(tree.MAXLOG) += 1
+
+	tree.jump = make([][]int, tree.MAXLOG)
+	for j := 0; j < tree.MAXLOG; j++ {
+		tree.jump[j] = make([]int, numbersVertex)
+	}
+
+	tree.edges = make([][]int, numbersVertex)
+	for _, e := range edges {
+		tree.addEdge(e.from, e.to)
+	}
+
+	return tree
+}
+
+// For each node, we will precompute its ancestor above him, its ancestor two nodes above, its ancestor four nodes above, etc.
+// Let's call `jump[j][u]` is the `2^j`-th ancestor above the node `u` with `u` in range `[0, numbersVertex)`, `j` in range `[0,MAXLOG)`.
+// These information allow us to jump from any node to any ancestor above it in `O(MAXLOG)` time.
+func LowestCommonAncestor(tree *Tree) {
+	// call dfs to compute depth from the root to each node and the parent of each node.
+	tree.dfs(tree.root, tree.root)
+
+	// compute jump[j][u]
+	for j := 1; j < tree.MAXLOG; j++ {
+		for u := 0; u < tree.numbersVertex; u++ {
+			tree.jump[j][u] = tree.jump[j-1][tree.jump[j-1][u]]
+		}
+	}
+}

--- a/__temp6/mobius_test.go
+++ b/__temp6/mobius_test.go
@@ -1,0 +1,41 @@
+// mobius_test.go
+// description: Returns μ(n)
+// author: Akshay Dubey (https://github.com/itsAkshayDubey)
+// see mobius.go
+
+package math_test
+
+import (
+	"testing"
+
+	algmath "github.com/TheAlgorithms/Go/math"
+)
+
+func TestMu(t *testing.T) {
+	var tests = []struct {
+		n        int
+		expected int
+	}{
+		{-1, 1},
+		{0, 1},
+		{2, -1},
+		{3, -1},
+		{95, 1},
+		{97, -1},
+		{98, 0},
+		{99, 0},
+		{100, 0},
+	}
+	for _, test := range tests {
+		result := algmath.Mu(test.n)
+		t.Log(test.n, " ", result)
+		if result != test.expected {
+			t.Errorf("Wrong result! Expected:%v, returned:%v ", test.expected, result)
+		}
+	}
+}
+func BenchmarkMu(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		algmath.Mu(65536)
+	}
+}

--- a/__temp6/postfix_evaluation.cpp
+++ b/__temp6/postfix_evaluation.cpp
@@ -1,0 +1,214 @@
+/**
+ * @file
+ * @brief Evaluation of [Postfix
+ * Expression](https://en.wikipedia.org/wiki/Reverse_Polish_notation)
+ * @author [Darshana Sarma](https://github.com/Darshana-Sarma)
+ * @details
+ * Create a stack to store operands (or values).
+ * Scan the given expression and do following for every scanned element.
+ * If the element is a number, push it into the stack
+ * If the element is a operator, pop operands for the operator from stack.
+ * Evaluate the operator and push the result back to the stack
+ * When the expression is ended, the number in the stack is the final answer
+ */
+#include <algorithm>  // for all_of
+#include <cassert>    // for assert
+#include <iostream>   // for io operations
+#include <stack>      // for std::stack
+#include <string>     // for stof
+#include <vector>     // for std::vector
+
+/**
+ * @namespace others
+ * @brief Other algorithms
+ */
+namespace others {
+/**
+ * @namespace postfix_expression
+ * @brief Functions for Postfix Expression algorithm
+ */
+namespace postfix_expression {
+
+/**
+ * @brief Checks if scanned string is a number
+ * @param s scanned string
+ * @returns bool boolean value if string is number
+ */
+bool is_number(const std::string &s) {
+    return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
+}
+
+/**
+ * @brief Evaluate answer using given last two operands from and operation
+ * @param a second last added operand which will be used for evaluation
+ * @param b last added operand which will be used for evaluation
+ * @param operation to be performed with respective floats
+ * @param stack containing numbers
+ * @returns none
+ */
+void evaluate(float a, float b, const std::string &operation,
+              std::stack<float> &stack) {
+    float c = 0;
+    const char *op = operation.c_str();
+    switch (*op) {
+        case '+':
+            c = a + b;  // Addition of numbers
+            stack.push(c);
+            break;
+
+        case '-':
+            c = a - b;  // Subtraction of numbers
+            stack.push(c);
+            break;
+
+        case '*':
+            c = a * b;  // Multiplication of numbers
+            stack.push(c);
+            break;
+
+        case '/':
+            c = a / b;  // Division of numbers
+            stack.push(c);
+            break;
+
+        default:
+            std::cout << "Operator not defined\n";
+            break;
+    }
+}
+
+namespace {
+float remove_from_stack(std::stack<float> &stack) {
+    if (stack.empty()) {
+        throw std::invalid_argument("Not enough operands");
+    }
+    const auto res = stack.top();
+    stack.pop();
+    return res;
+}
+}  // namespace
+
+/**
+ * @brief Postfix Evaluation algorithm to compute the value from given input
+ * array
+ * @param input vector of strings consisting of numbers and operations
+ * @returns stack[stackTop] returns the top value from the stack
+ */
+float postfix_evaluation(const std::vector<std::string> &input) {
+    std::stack<float> stack;
+
+    for (const auto &scan : input) {
+        if (is_number(scan)) {
+            stack.push(std::stof(scan));
+
+        } else {
+            const auto op2 = remove_from_stack(stack);
+            const auto op1 = remove_from_stack(stack);
+
+            evaluate(op1, op2, scan, stack);
+        }
+    }
+
+    const auto res = remove_from_stack(stack);
+    if (!stack.empty()) {
+        throw std::invalid_argument("Too many operands");
+    }
+    return res;
+}
+}  // namespace postfix_expression
+}  // namespace others
+
+/**
+ * @brief Test function 1 with input array
+ * {'2', '3', '1', '*', '+', '9', '-'}
+ * @returns none
+ */
+static void test_function_1() {
+    std::vector<std::string> input = {"2", "3", "1", "*", "+", "9", "-"};
+
+    float answer = others::postfix_expression::postfix_evaluation(input);
+
+    assert(answer == -4);
+}
+
+/**
+ * @brief Test function 2 with input array
+ * {'100', '200', '+', '2', '/', '5', '*', '7', '+'}
+ * @returns none
+ */
+static void test_function_2() {
+    std::vector<std::string> input = {"100", "200", "+", "2", "/",
+                                      "5",   "*",   "7", "+"};
+    float answer = others::postfix_expression::postfix_evaluation(input);
+
+    assert(answer == 757);
+}
+
+static void test_function_3() {
+    std::vector<std::string> input = {
+        "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1",
+        "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1",
+        "+", "+", "+", "+", "+", "+", "+", "+", "+", "+", "+",
+        "+", "+", "+", "+", "+", "+", "+", "+", "+", "+"};
+    float answer = others::postfix_expression::postfix_evaluation(input);
+
+    assert(answer == 22);
+}
+
+static void test_single_input() {
+    std::vector<std::string> input = {"1"};
+    float answer = others::postfix_expression::postfix_evaluation(input);
+
+    assert(answer == 1);
+}
+
+static void test_not_enough_operands() {
+    std::vector<std::string> input = {"+"};
+    bool throws = false;
+    try {
+        others::postfix_expression::postfix_evaluation(input);
+    } catch (std::invalid_argument &) {
+        throws = true;
+    }
+    assert(throws);
+}
+
+static void test_not_enough_operands_empty_input() {
+    std::vector<std::string> input = {};
+    bool throws = false;
+    try {
+        others::postfix_expression::postfix_evaluation(input);
+    } catch (std::invalid_argument &) {
+        throws = true;
+    }
+    assert(throws);
+}
+
+static void test_too_many_operands() {
+    std::vector<std::string> input = {"1", "2"};
+    bool throws = false;
+    try {
+        others::postfix_expression::postfix_evaluation(input);
+    } catch (std::invalid_argument &) {
+        throws = true;
+    }
+    assert(throws);
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test_function_1();
+    test_function_2();
+    test_function_3();
+    test_single_input();
+    test_not_enough_operands();
+    test_not_enough_operands_empty_input();
+    test_too_many_operands();
+
+    std::cout << "\nTest implementations passed!\n";
+
+    return 0;
+}


### PR DESCRIPTION
51 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.